### PR TITLE
HttpServer: Remove all leading slashes of served files

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -854,7 +854,7 @@ bool HttpServer::searchAndServeFile(HttpData& data) const
   // TODO: WOULD BE NICE TO CACHE STRING CONSTRUCTION.
 
   QString urlPath = data.getRequest().getUrl().getPath();
-  if(urlPath.startsWith('/'))
+  while(urlPath.startsWith('/'))
   {
     urlPath = urlPath.mid(1);
   }


### PR DESCRIPTION
Previously only one leading slash was removed. This would lead to problems
with the following Qt calls if there was more than one slash in the URL.
The path would not be relative to `m_ServeFilesDirectory` but would be
treated as absolute, leading to an error message because `HttpServer`
does not allow reading outside of `m_ServeFilesDirectory`
(and rightfully so).

Signed-off-by: Lennart Sauerbeck <lennart.sauerbeck@sevencs.com>