### PR TITLE
Swagger: Implement `responses` object for endpoints

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -139,6 +139,11 @@ std::vector<Input> Action::getInputs() const
   return EMPTY_INPUTS;
 }
 
+std::map<qttp::HttpStatus, QString> Action::getResponses() const
+{
+  return {};
+}
+
 std::vector<QStringPair> Action::getHeaders() const
 {
   return Global::getDefaultHeaders();

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -256,6 +256,16 @@ std::vector<Input> SimpleAction::getInputs() const
   return m_Inputs;
 }
 
+void SimpleAction::setResponses(const std::map<qttp::HttpStatus, QString>& responses)
+{
+  m_Responses.insert(responses.begin(), responses.end());
+}
+
+std::map<qttp::HttpStatus, QString> SimpleAction::getResponses() const
+{
+  return m_Responses;
+}
+
 std::vector<QStringPair> SimpleAction::getHeaders() const
 {
   return m_Headers;

--- a/src/action.h
+++ b/src/action.h
@@ -123,6 +123,9 @@ class QTTPSHARED_EXPORT SimpleAction : public Action
     void setInputs(const std::vector<Input>& inputs);
     std::vector<Input> getInputs() const;
 
+    void setResponses(const std::map<qttp::HttpStatus, QString>& responses);
+    std::map<qttp::HttpStatus, QString> getResponses() const;
+
 QTTP_PROTECTED:
 
     std::vector<QStringPair> getHeaders() const;
@@ -136,6 +139,7 @@ QTTP_PRIVATE:
     QByteArray m_Description;
     QStringList m_Tags;
     std::vector<Input> m_Inputs;
+    std::map<qttp::HttpStatus, QString> m_Responses;
     std::vector<QStringPair> m_Headers;
 };
 

--- a/src/action.h
+++ b/src/action.h
@@ -1,6 +1,8 @@
 #ifndef QTTPACTION_H
 #define QTTPACTION_H
 
+#include <map>
+
 #include "qttp_global.h"
 #include "httproute.h"
 #include "httpdata.h"
@@ -59,6 +61,9 @@ class QTTPSHARED_EXPORT Action
 
     //! The inputs help SwaggerUI include parameters.
     virtual std::vector<Input> getInputs() const;
+
+    //! The possible responses of this action - used for SwaggerUI.
+    virtual std::map<qttp::HttpStatus, QString> getResponses() const;
 
     bool registerRoute(HttpMethod method, const QString& path, Visibility visibility = Visibility::Show);
     bool registerRoute(const qttp::HttpPath& path, Visibility visibility = Visibility::Show);

--- a/src/swagger.cpp
+++ b/src/swagger.cpp
@@ -84,6 +84,14 @@ void Swagger::initialize()
     QJsonArray required;
     QJsonArray tags = QJsonArray::fromStringList(action->getTags());
 
+    QJsonObject responses;
+    for(auto response : action->getResponses())
+    {
+      responses.insert(QString::number(static_cast<int>(response.first)), QJsonObject {
+        { "description", response.second }
+      });
+    }
+
     QString actionName = action->getName();
     const vector<Input> & inputs = action->getInputs();
 
@@ -216,7 +224,8 @@ void Swagger::initialize()
           { "description", action->getDescription() },
           { "operationId", routePath },
           { "parameters", routeParameters },
-          { "tags", tags }
+          { "tags", tags },
+          { "responses", responses }
         });
         paths[routePath] = pathRoute;
       }


### PR DESCRIPTION
For easier documentation each response code can now be documented
by itself. For now the only supported field is `description` which
is also the only required field as per the specification.

Signed-off-by: Lennart Sauerbeck <lennart.sauerbeck@sevencs.com>