### PR TITLE
HttpRoute and HttpServer: Add overloading methods that specify context data

### DIFF
--- a/src/httproute.cpp
+++ b/src/httproute.cpp
@@ -50,6 +50,19 @@ Input::Input(const QString& inputname, const std::set<qttp::HttpPath>& path) :
 {
 }
 
+Input::Input(const QString& inputname, const QString& dataType, const std::set<qttp::HttpPath>& paths) :
+  name(inputname),
+  description(),
+  isRequired(false),
+  paramType("query"),
+  dataType(dataType),
+  values(),
+  visibility(Visibility::Show),
+  paths(paths)
+{
+}
+
+
 Input::Input(const QString& inputname, const QString& desc, const QStringList& vals, const std::set<qttp::HttpPath>& path) :
   name(inputname),
   description(desc),

--- a/src/httproute.cpp
+++ b/src/httproute.cpp
@@ -62,6 +62,19 @@ Input::Input(const QString& inputname, const QString& dataType, const std::set<q
 {
 }
 
+Input::Input(const QString& inputname, const QString& dataType, const QString& desc, const std::set<qttp::HttpPath>& paths) :
+    name(inputname),
+    description(desc),
+    isRequired(false),
+    paramType("query"),
+    dataType(dataType),
+    values(),
+    visibility(Visibility::Show),
+    paths(paths)
+{
+}
+
+
 
 Input::Input(const QString& inputname, const QString& desc, const QStringList& vals, const std::set<qttp::HttpPath>& path) :
   name(inputname),

--- a/src/httproute.h
+++ b/src/httproute.h
@@ -18,6 +18,7 @@ class QTTPSHARED_EXPORT Input
     Input(const Input& from);
     Input(const QString& name, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
     Input(const QString& name, const QString& dataType, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
+    Input(const QString& name, const QString& dataType, const QString& desc, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
     Input(const QString& name, const QString& desc, const QStringList& values, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
 
     Input& operator=(const Input& from);

--- a/src/httproute.h
+++ b/src/httproute.h
@@ -17,6 +17,7 @@ class QTTPSHARED_EXPORT Input
     Input(Input&& from);
     Input(const Input& from);
     Input(const QString& name, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
+    Input(const QString& name, const QString& dataType, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
     Input(const QString& name, const QString& desc, const QStringList& values, const std::set<qttp::HttpPath>& paths = std::set<qttp::HttpPath>());
 
     Input& operator=(const Input& from);

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -155,6 +155,19 @@ class QTTPSHARED_EXPORT HttpServer : public QObject
       return action;
     }
 
+    template<class T, class P> std::shared_ptr<Action> addActionAndRegister(P& param,
+                                                                            Visibility visibilty = Visibility::Show)
+    {
+      std::shared_ptr<Action> action(new T(param));
+      HttpServer::addAction(action);
+      auto routes = action->getRoutes();
+      for(const auto & path : routes)
+      {
+        HttpServer::registerRoute(action, path, visibilty);
+      }
+      return action;
+    }
+
     /**
      * @brief A template method to register a processor via the Processor interface.
      */

--- a/www/index.html
+++ b/www/index.html
@@ -39,11 +39,12 @@
 
     <script type="text/javascript">
         $(function() {
+            var ip = window.location.hostname;
             var url = window.location.search.match(/url=([^&]+)/);
             if (url && url.length > 1) {
                 url = decodeURIComponent(url[1]);
             } else {
-                url = "http://localhost:8080/swagger";
+                url = "http://" + ip + ":8080/swagger";
             }
 
             hljs.configure({
@@ -56,6 +57,7 @@
             }
             window.swaggerUi = new SwaggerUi({
                 url: url,
+                validatorUrl : null,
                 dom_id: "swagger-ui-container",
                 supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
                 onComplete: function(swaggerApi, swaggerUi) {
@@ -102,7 +104,7 @@
 <body class="swagger-section">
     <div id='header'>
         <div class="swagger-ui-wrap">
-            <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title" id="logo_title"></span></a>
+            <a idz="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title" id="logo_title"></span></a>
             <form id='api_selector'>
                 <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text" /></div>
                 <div id='auth_container'></div>


### PR DESCRIPTION
Added new functions to HttpRoute and HttpServer.

HttpServer now supports the ability to pass in generic parameters into any classes extending the Action class.

HttpRoute now has a constructor that supports the ability to specify the dataType  alongside the path and input name.